### PR TITLE
add x86_64 > x64 mapping for darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ llrt-linux-arm64.zip: | clean-js js
 	zip -j $@ target/$(TARGET_linux_arm64)/release/llrt
 
 llrt-linux-x86_64.zip: llrt-linux-x64.zip
+llrt-darwin-x86_64.zip: llrt-darwin-x64.zip
 
 define release_template
 release-${1}: | clean-js js


### PR DESCRIPTION
### Issue # (if available)

(skipped issue; will open if desired.)

### Description of changes

add `Makefile` target to redirect `llrt-darwin-x86_64.zip` to `llrt-darwin-x64.zip`, mirroring the same logic used for linux. It's a one-line Makefile change, so it shouldn't impact any of the code.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
